### PR TITLE
Update to RST 30h system API

### DIFF
--- a/zloader/api.asm
+++ b/zloader/api.asm
@@ -1,0 +1,13 @@
+; Command codes for the RST 30h system API. These are the values that go into the 'C' register
+A_PGSEL      EQU    1h    ; Map a memory page into a block number
+A_TXCHR      EQU    2h    ; Send character to stdout
+A_RXCHR      EQU    3h    ; Wait for/return next character (stdin)
+A_CHKCH      EQU    4h    ; Check for character (stdin)
+A_DSKMP      EQU    5h    ; Disk drive map
+A_DSKDM      EQU    6h    ; Disk set DMA address
+A_DSKRD      EQU    7h    ; Disk read
+A_DSKRW      EQU    8h    ; Disk raw-read
+A_DSKWR      EQU    9h    ; Disk write
+
+; ZLoader private calls
+S_DSKDM      EQU    86h   ; Set DMA address to ZLoader buffer (no params)

--- a/zloader/appl.asm
+++ b/zloader/appl.asm
@@ -3,11 +3,13 @@ import config.asm
 
 ; appl.asm
 ; This code is assembled to be located in the top 512 bytes of RAM and be
-; copied to the application address space. The code is assembled to load
-; from 0xFE00 (512 bytes) but set to load into address 0x3E00 (end of page zero)
+; copied there from the application address space. To do this the origin is
+; set to $3E00 (where it'll reside in the hex output records) and the `phase`
+;  directive tells the assember to treat the code as though it is running
+; from $FE00.
 
             public AP_ST, END_APP
-            extrn  CONTXT, APP_STK, PAGE_MP, MON_MP, AP_DISP
+            extrn  CONTXT, PAGE_MP, MON_MP, AP_DISP, APP_STK
 
             ASEG
             ORG   $3E00
@@ -20,35 +22,42 @@ AP_ST:    LD    A,(CONTXT)
           OR    A
           JR    Z,_issup        ; Running in ZLoader context so no changes required.
 
-          ; Map ZLoader into memory (Block 0)
+          ; Map ZLoader into memory (Block 0). 'A' can't be used to pass parameters and
+          ; doesn't need to be saved.
           DI
           LD    A,(MON_MP)      ; Page mask for page zero monitor
           OUT   (PG_PORT0),A
 
           ; Save the application stack
-          LD     (APP_STK),SP       ; Save the application stack
-
-          LD     SP,SP_STK      ; Replace with supervisor stack
+          LD     (APP_STK),SP      ; Save the application stack
+          LD     SP,SP_STK         ; Replace with supervisor stack
           EI
 
           ; Make the end handler unwind the service changes
-          LD     HL,AP_END
-          PUSH   HL
+          PUSH   HL                ; Need to preserve the content of HL
+          LD     HL,AP_END         ; while pushing the restore address
+          EX     (SP),HL
 
           ; And go the the dispatcher
           JR     AP_DISP
 
-; Request make from within the ZLoader so no complicated memory changes. Just invoke the dispatcher.
-_issup:   LD     HL, Z_END          ; How to restore context
-          PUSH   HL
+; Request made from within the ZLoader so no complicated memory changes. Just invoke the dispatcher.
+_issup:   PUSH   HL                ; Need to preserve the content of HL
+          LD     HL, Z_END         ; while pushing the restore address
+          EX     (SP),HL
 _dis:     JR     AP_DISP
 
 ; At the end of a dispatch called by the application, map application memory back and repair the stack
-AP_END:   DI
+AP_END:   LD     (SAVA),A       ; A needs to be preserved - many contain API results
+          DI
           LD     SP,(APP_STK)   ; Got the appication stack back but it might not be in our address space so can't use
           LD     A,(PAGE_MP)
           OUT    (PG_PORT0),A   ; Back into application space
           EI                    ; Safe to allow interrupts again
+          LD     A,(SAVA)       ; Restore A. The flags are unchanged
 Z_END:    RET                   ; And carry on
+
+SAVSTK:   DS     2
+SAVA:     DS     1
 
 END_APP:  EQU    $

--- a/zloader/appl.asm
+++ b/zloader/appl.asm
@@ -13,21 +13,20 @@ import config.asm
             ORG   $3E00
             PHASE $FE00
 
+
 ; Entry point for the command handler. Action depends on whether this is called
 ; from ZLoader or from the application. Use the CONTXT to decide.
 AP_ST:    LD    A,(CONTXT)
           OR    A
-          JR    Z,_issup       ; Running in ZLoader context so no changes required.
+          JR    Z,_issup        ; Running in ZLoader context so no changes required.
 
           ; Map ZLoader into memory (Block 0)
           DI
-          LD    A,(MON_MP)     ; Page mask for page zero monitor
+          LD    A,(MON_MP)      ; Page mask for page zero monitor
           OUT   (PG_PORT0),A
 
           ; Save the application stack
-          ; -------------------ZMAC-----------------------------
-          LD     (APP_STK),SP   ; Save the application stack
-          ; LD     (1000),SP     ; Save the application stack
+          LD     (APP_STK),SP       ; Save the application stack
 
           LD     SP,SP_STK      ; Replace with supervisor stack
           EI
@@ -37,9 +36,7 @@ AP_ST:    LD    A,(CONTXT)
           PUSH   HL
 
           ; And go the the dispatcher
-          ; -------------------ZMAC-----------------------------
           JR     AP_DISP
-          ; JR     _dis
 
 ; Request make from within the ZLoader so no complicated memory changes. Just invoke the dispatcher.
 _issup:   LD     HL, Z_END          ; How to restore context

--- a/zloader/appl.asm
+++ b/zloader/appl.asm
@@ -1,0 +1,52 @@
+import ../zlib/defs.asm
+import config.asm
+
+; appl.asm
+; This code is assembled to be located in the top 512 bytes of RAM and be
+; copied to the application address space. The code is assembled to load
+; from 0xFE00 (512 bytes) but set to load into address 0x3E00 (end of page zero)
+
+            public AP_ST, END_APP
+            extrn  CONTXT, APP_STK, PAGE_MP, MON_MP, AP_DISP
+
+            ASEG
+            ORG   $3E00
+            PHASE $FE00
+
+; Entry point for the command handler. Action depends on whether this is called
+; from ZLoader or from the application. Use the CONTXT to decide.
+AP_ST:    LD    A,(CONTXT)
+          OR    A
+          JR    Z,_issup       ; Running in ZLoader context so no changes required.
+
+          ; Map ZLoader into memory (Block 0)
+          DI
+          LD    A,(MON_MP)     ; Page mask for page zero monitor
+          OUT   (PG_PORT0),A
+
+          ; Save the application stack
+          LD     (APP_STK),SP   ; Save the application stack
+          LD     SP,SP_STK      ; Replace with supervisor stack
+          EI
+
+          ; Make the end handler unwind the service changes
+          LD     HL,AP_END
+          PUSH   HL
+
+          ; And go the the dispatcher
+          JR     AP_DISP
+
+; Request make from within the ZLoader so no complicated memory changes. Just invoke the dispatcher.
+_issup:   LD     HL, Z_END          ; How to restore context
+          PUSH   HL
+          JR     AP_DISP
+
+; At the end of a dispatch called by the application, map application memory back and repair the stack
+AP_END:   DI
+          LD     SP,(APP_STK)   ; Got the appication stack back but it might not be in our address space so can't use
+          LD     A,(PAGE_MP)
+          OUT    (PG_PORT0),A   ; Back into application space
+          EI                    ; Safe to allow interrupts again
+Z_END:    RET                   ; And carry on
+
+END_APP:  EQU    $

--- a/zloader/appl.asm
+++ b/zloader/appl.asm
@@ -25,7 +25,10 @@ AP_ST:    LD    A,(CONTXT)
           OUT   (PG_PORT0),A
 
           ; Save the application stack
+          ; -------------------ZMAC-----------------------------
           LD     (APP_STK),SP   ; Save the application stack
+          ; LD     (1000),SP     ; Save the application stack
+
           LD     SP,SP_STK      ; Replace with supervisor stack
           EI
 
@@ -34,12 +37,14 @@ AP_ST:    LD    A,(CONTXT)
           PUSH   HL
 
           ; And go the the dispatcher
+          ; -------------------ZMAC-----------------------------
           JR     AP_DISP
+          ; JR     _dis
 
 ; Request make from within the ZLoader so no complicated memory changes. Just invoke the dispatcher.
 _issup:   LD     HL, Z_END          ; How to restore context
           PUSH   HL
-          JR     AP_DISP
+_dis:     JR     AP_DISP
 
 ; At the end of a dispatch called by the application, map application memory back and repair the stack
 AP_END:   DI

--- a/zloader/mk.sh
+++ b/zloader/mk.sh
@@ -10,12 +10,14 @@ if [ -z "$RELEASE" ]; then
   zmac -j -J --rel7 --oo obj,lst ./loader.asm
   zmac -j -J --rel7 --oo obj,lst ./commands.asm
   zmac -j -J --rel7 --oo obj,lst ./disassembler.asm
+  zmac -j -J --rel7 --oo obj,lst ./appl.asm
 else
   echo "Building RELEASE version"
   zmac -DRELEASE -j -J --rel7 --oo obj,lst ./services.asm
   zmac -DRELEASE -j -J --rel7 --oo obj,lst ./loader.asm
   zmac -DRELEASE -j -J --rel7 --oo obj,lst ./commands.asm
   zmac -DRELEASE -j -J --rel7 --oo obj,lst ./disassembler.asm
+  zmac -DRELEASE -j -J --rel7 --oo obj,lst ./appl.asm
 fi
 
-ld80 -o ./loader.hex -P 0100 -D 3000 -C LNBUF,3800 -O ihex -s - -m ./zout/loader.rel ./zout/services.rel ./zout/commands.rel ./zout/disassembler.rel ../zlib/zout/libutils.rel ../zlib/zout/libsio.rel ../zlib/zout/libcmd.rel ../zlib/zout/libconin.rel ../zlib/zout/libconout.rel ../zlib/zout/libspi.rel ../zlib/zout/libsdc.rel ../zlib/zout/libi2c.rel ../zlib/zout/librtc.rel
+ld80 -o ./loader.hex -P 0100 -D 3000 -O ihex -s - -m ./zout/loader.rel ./zout/services.rel ./zout/commands.rel ./zout/disassembler.rel ./zout/appl.rel ../zlib/zout/libutils.rel ../zlib/zout/libsio.rel ../zlib/zout/libcmd.rel ../zlib/zout/libconin.rel ../zlib/zout/libconout.rel ../zlib/zout/libspi.rel ../zlib/zout/libsdc.rel ../zlib/zout/libi2c.rel ../zlib/zout/librtc.rel

--- a/zloader/services.asm
+++ b/zloader/services.asm
@@ -6,8 +6,10 @@ import config.asm
           extrn  PGADJ
 
           extrn  PGREST
-          extrn  ENDDIS,ERRDIS
           extrn  DRVMAP
+          extrn  PRINT_LN
+          extrn  _IOERR
+          extrn  MON_MP, SDPAGE
 
           public  AP_DISP
 
@@ -26,7 +28,8 @@ CSEG
 ;  8: SD Card Write
 ;
 ; All other registers are command specific.
-AP_DISP:  DEC    C
+AP_DISP:  LD     A,C
+          DEC    C
           JR     Z,LD_PGSEL     ; CMD 1 - RAM Page Select (map)
           DEC    C
           JR     Z,TX_CHR       ; CMD 2 - Send character to serial port A
@@ -42,6 +45,11 @@ AP_DISP:  DEC    C
           JR     Z,LD_SDRD      ; CMD 7 - SDCard Read
           DEC    C
           JR     Z,LD_SDWR      ; CMD 8 - SDCard Write
+
+          ; System requests (internal calls from ZLoader context)
+          AND    7Fh
+          CP     6
+          JR     Z,LD_EDMA
 
           ; Unknown function
           RET
@@ -66,11 +74,11 @@ CHK_CHR:  RST    18h
 ; E:  The page number into which to map the physical memory (0-3).
 ; NOTE: Mapping page 0 is likely to be a problem!
 LD_PGSEL: LD     A,E
-          CP     4
-          JR     NC,ERRDIS      ; Only 4 pages. Store the page we're selecting
+          CP     3
+          RET    NC             ; There are 4 pages but the last one can't be changed by the application
           LD     HL,PAGE_MP
           ADD    L
-          LD     L,A             ; PAGE_MP will always be low in data store and not on a 256 byte boundary
+          LD     L,A            ; PAGE_MP will always be low in data store and not on a 256 byte boundary
           LD     A,D
           LD     (HL),A         ; Save the page we're about to map
           LD     A,PG_PORT0     ; Calculate the right port number for the requested block
@@ -89,7 +97,7 @@ LD_PGSEL: LD     A,E
 ; Translate into a page and offset and store in local memory
 LD_STDSK: LD     A,D
           CP     16
-          JR     NC,ENDDIS
+          RET    NC
 
           EX     DE,HL         ; DE <= physical block number
           LD     HL,DRVMAP     ; Mapping table base
@@ -118,12 +126,22 @@ LD_STDSK: LD     A,D
 
 ; --------- LD_STDMA (CMD 6)
 ; Record the address (in application space) of the SD Card DMA buffer
-; A  - Physical page number into which to write data
-; HL - Offset (14 bits) into the physical page number (WHY?!?!!??!?!)
+; HL - Address into application pages.
 ; Translate into a page and offset and store in local memory
 LD_STDMA: CALL   PGADJ
           LD     (DMA_PAGE),A
           LD     (DMA_ADDR),HL
+          CALL   SD_INIT
+          RET
+
+; --------- LD_STDMA (CMD 86)
+; Set the DMA address to the SDPage address. Fixed buffer so no
+; required parameters.
+LD_EDMA:  LD     A,(MON_MP)
+          LD     (DMA_PAGE),A
+          LD     HL,SDPAGE+0x4000
+          LD     (DMA_ADDR),HL
+          CALL   SD_INIT
           RET
 
 ; --------- LD_SDRD (CMD 7)
@@ -136,7 +154,6 @@ LD_SDRD:  CALL   _mapdsk              ; HLDE is now the physical offset into the
           LD     A,(DMA_PAGE)         ; Get the buffer page into block 1
           OUT    (PG_PORT0+1),A
 
-          CALL   SD_INIT
           CALL   SD_RBLK             ; Get the SDCard data
 
           CALL   PGREST              ; Reset the application memory page
@@ -152,25 +169,18 @@ LD_SDWR:  CALL   _mapdsk
           LD     A,(DMA_PAGE)         ; Get the buffer address into page 1
           OUT    (PG_PORT0+1),A
 
-          CALL   SD_INIT
           CALL   SD_WBLK
 
           CALL   PGREST               ; Reset the application memory page
           RET
 
 ; --------- _mapdsk
-; Application is writing to logical 32 bit address in HLDE. The upper 10 bits is the logical
+; Application is writing to logical 32 bit address in HLDE. The upper 8 bits are the logical
 ; disk number which needs to be mapped to a physical 4MB block. The logical disk number is
-; only 4 bits allowing 16 logical drives. Need H bits 0-1 and L bits 6-7 (unfortunate)
-_mapdsk:  LD     A,$C0
-          AND    L
-          RR     H          ; LS bit of H
-          RRA               ; Into MSB of A
-          RR     H          ; And again
-          RRA               ; A = logical disk * 16. Need *2 to get offset into drive table.
-          RRCA
-          RRCA
-          RRCA              ; Divide by 8 to get offset into DRVMAP table
+; only 4 bits allowing 16 logical drives.
+_mapdsk:  LD     A,H        ; The upper 8 bits needs to be mapped to the upper 10 bits
+          ADD    A
+
           ; A is now the offset into DRVMAP
           PUSH   DE         ; Stack <= LSWord
           PUSH   HL         ; Stack <= MSWord
@@ -182,16 +192,17 @@ _mapdsk:  LD     A,$C0
           LD     H,A        ; HL points to the correct logical drive.
           LD     E,(HL)
           INC    HL
-          LD     D,(HL)
+          LD     D,(HL)     ; DE is the content of the drive table: replacement upper 10 bits of absolute address
           POP    HL
           LD     A,L
-          AND    $3F
+          AND    $3F        ; Merge mapped bits into the provided address
           OR     E
           LD     L,A
           LD     H,D
-          POP    DE
-          ; HLDE is now the modified absolute disk address
+          POP    DE         ; Get the low order address bits back from the stack
           RET
+
+
 
           DSEG
 

--- a/zloader/services.asm
+++ b/zloader/services.asm
@@ -9,7 +9,7 @@ import config.asm
           extrn  ENDDIS,ERRDIS
           extrn  DRVMAP
 
-          public DISPATCH
+          public  AP_DISP
 
 CSEG
 
@@ -26,7 +26,7 @@ CSEG
 ;  8: SD Card Write
 ;
 ; All other registers are command specific.
-DISPATCH: DEC    C
+AP_DISP:  DEC    C
           JR     Z,LD_PGSEL     ; CMD 1 - RAM Page Select (map)
           DEC    C
           JR     Z,TX_CHR       ; CMD 2 - Send character to serial port A


### PR DESCRIPTION
+ Changes to 'libsdc' to use sector addressing to SDCards rather than byte addressing. Allows future support for larger SDCards without application changes.